### PR TITLE
Bank OCR

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ project/plugins/project/
 *.class
 *.log
 .idea/*
+coverallsToken.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: scala
 scala:
-   - 2.9.3
-   - 2.10.6
-   - 2.11.11
-   - 2.12.2
+   - 2.12.4
 jdk:
      - oraclejdk7
-     - openjdk6
 script:
   - sbt clean coverage test
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,7 @@ scala:
 jdk:
      - oraclejdk7
      - openjdk6
-sbt_args: -no-colors -J-Xss2m
+script:
+  - sbt clean coverage test
+after_success:
+    - sbt coverageReport

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ jdk:
 script:
   - sbt clean coverage test
 after_success:
-    - sbt coverageReport
+    - sbt coverageReport coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # katas
 
-[![Build Status](https://travis-ci.org/jennygrahamjones/katas.svg?branch=master)](https://travis-ci.org/jennygrahamjones/katas)
+[![Build Status](https://travis-ci.org/jennygrahamjones/katas.svg?branch=master)](https://travis-ci.org/jennygrahamjones/katas) [![Coverage Status](https://coveralls.io/repos/github/jennygrahamjones/katas/badge.svg?branch=master)](https://coveralls.io/github/jennygrahamjones/katas?branch=master)
 
-solutions for katas including.
+solutions for katas.

--- a/build.sbt
+++ b/build.sbt
@@ -10,3 +10,8 @@ libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 import org.scoverage.coveralls.Imports.CoverallsKeys._
 
 coverallsTokenFile := Some("./coverallsToken.txt")
+
+coverageEnabled := true
+coverageMinimum := 100
+coverageFailOnMinimum := true
+coverageHighlighting := true

--- a/build.sbt
+++ b/build.sbt
@@ -6,4 +6,7 @@ scalaVersion := "2.12.4"
 
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.0.4"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.4" % "test"
-        
+
+import org.scoverage.coveralls.Imports.CoverallsKeys._
+
+coverallsTokenFile := Some("./coverallsToken.txt")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,3 +1,5 @@
 sbt.version = 1.0.4
 
 coverageEnabled := true
+coverageMinimum := 90
+coverageFailOnMinimum := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,5 +1,1 @@
 sbt.version = 1.0.4
-
-coverageEnabled := true
-coverageMinimum := 90
-coverageFailOnMinimum := true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,3 @@
 sbt.version = 1.0.4
+
+coverageEnabled := true

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.2")

--- a/src/main/scala/BankOCR.scala
+++ b/src/main/scala/BankOCR.scala
@@ -51,9 +51,9 @@ object BankOCR {
 
   def evaluateChecksum(input: String): Boolean = {
     val str: List[Int] = input.map(_.toString).map(_.toInt).toList
-    val strFormattedAsChecksum = Checksum(str.head, str(1), str(2), str(3), str(4), str(5), str(6), str(7), str(8))
+    val productForEvaluation = str.reverse.zipWithIndex.map(x => x._1 * (x._2 + 1)).sum
 
-    if (strFormattedAsChecksum.isValid) {
+    if (productForEvaluation % 11 == 0) {
       true
     } else {
       throw new InvalidChecksumException("checksum invalid")
@@ -61,12 +61,6 @@ object BankOCR {
   }
 
   class InvalidChecksumException(msg: String) extends Exception(msg)
-
-  case class Checksum(nine: Int, eight: Int, seven: Int, six: Int, five: Int, four: Int, three: Int, two: Int, one: Int) {
-    def isValid: Boolean = {
-      ((one + 2) * (two + 3) * (three + 4) * (four + 5) * (five + 6) * (six + 7) * (seven + 8) * (eight + 9) * nine) % 11 == 0
-    }
-  }
 
   case class AccountNumberInput(top: String, middle: String, bottom: String) {
 
@@ -89,4 +83,5 @@ object BankOCR {
     }
 
   }
+
 }

--- a/src/main/scala/BankOCR.scala
+++ b/src/main/scala/BankOCR.scala
@@ -61,7 +61,6 @@ object BankOCR {
   }
 
   case class AccountNumberInput(top: String, middle: String, bottom: String) {
-    override def toString: String = top + middle + bottom
 
     def digitiser(start: Int, end: Int): String = {
       val num: String = top.substring(start, end) + middle.substring(start, end) + bottom.substring(start, end)

--- a/src/main/scala/BankOCR.scala
+++ b/src/main/scala/BankOCR.scala
@@ -1,3 +1,5 @@
+import scala.util.{Failure, Success, Try}
+
 object BankOCR {
 
   val pattern = Map(" _ " +
@@ -6,6 +8,9 @@ object BankOCR {
                     "   " +
                     " | " +
                     " | " -> "1",
+                    "   " +
+                    "  |" +
+                    "  |" -> "1",
                     " _ " +
                     " _|" +
                     "|_ " -> "2",
@@ -29,32 +34,54 @@ object BankOCR {
                     "|_|" -> "8",
                     " _ " +
                     "|_|" +
-                    "  |" -> "9"
+                    " _|" -> "9"
                     )
 
-  case class CR(top: String, middle: String, bottom: String) {
+  def readInput(input: String): String = {
+    val accountNumberAsDigits: String = AccountNumberInput(input.substring(0, 27), input.substring(27, 54), input.substring(54, 81)).digits
+    if(accountNumberAsDigits.contains("?")) accountNumberAsDigits + " ILL"
+    else Try(evaluateChecksum(accountNumberAsDigits)) match {
+      case Success(_) => accountNumberAsDigits
+      case Failure(_) => accountNumberAsDigits + " ERR"
+    }
+  }
+
+  def evaluateChecksum(input: String): Boolean = {
+    val str: List[Int] = input.map(_.toString).map(_.toInt).toList
+    val strFormattedAsChecksum = Checksum(str.head,str(1),str(2),str(3),str(4),str(5),str(6),str(7),str(8))
+    if(strFormattedAsChecksum.isValid) true else throw new InvalidChecksumException("checksum invalid")
+  }
+
+  class InvalidChecksumException(msg: String) extends Exception(msg)
+
+  case class Checksum(nine: Int, eight: Int, seven: Int, six: Int, five: Int, four: Int, three: Int, two: Int, one: Int) {
+    def isValid: Boolean = {
+      ((one + 2) * (two + 3) * (three + 4) * (four + 5) * (five + 6) * (six + 7) * (seven + 8) * (eight + 9) * nine) % 11 == 0
+    }
+  }
+
+  case class AccountNumberInput(top: String, middle: String, bottom: String) {
     override def toString: String = top + middle + bottom
 
-    def digitiser(start: Int, end: Int): String =
-      top.substring(start,end) + middle.substring(start,end) + bottom.substring(start,end)
+    def digitiser(start: Int, end: Int): String = {
+      val num: String = top.substring(start, end) + middle.substring(start, end) + bottom.substring(start, end)
+      val tryPattern: Try[String] = Try(pattern(num))
 
-    val firstDigit: String = digitiser(0,3)
-    val secondDigit: String = digitiser(3,6)
-    val thirdDigit: String = digitiser(6,9)
-    val fourthDigit: String = digitiser(9,12)
-    val fifthDigit: String = digitiser(12,15)
-    val sixthDigit: String = digitiser(15,18)
-    val seventhDigit: String = digitiser(18,21)
-    val eighthDigit: String = digitiser(21,24)
-    val ninthDigit: String = digitiser(24,27)
+      tryPattern match {
+        case Success(_) => pattern(num)
+        case Failure(_) => "?"
+      }
+    }
 
-    val digits: String = pattern(this.firstDigit) + pattern(this.secondDigit) + pattern(this.thirdDigit) +
-      pattern(this.fourthDigit) + pattern(this.fifthDigit) + pattern(this.sixthDigit) +
-      pattern(this.seventhDigit) + pattern(this.eighthDigit) + pattern(this.ninthDigit)
+    val firstDigit: String = digitiser(0, 3)
+    val secondDigit: String = digitiser(3, 6)
+    val thirdDigit: String = digitiser(6, 9)
+    val fourthDigit: String = digitiser(9, 12)
+    val fifthDigit: String = digitiser(12, 15)
+    val sixthDigit: String = digitiser(15, 18)
+    val seventhDigit: String = digitiser(18, 21)
+    val eighthDigit: String = digitiser(21, 24)
+    val ninthDigit: String = digitiser(24, 27)
+    val digits: String = firstDigit + secondDigit + thirdDigit + fourthDigit + fifthDigit + sixthDigit + seventhDigit + eighthDigit + ninthDigit
   }
-
-  def readInput(input: String): String = {
-    CR(input.substring(0, 27), input.substring(27, 54), input.substring(54, 81)).digits
-  }
-
 }

--- a/src/main/scala/BankOCR.scala
+++ b/src/main/scala/BankOCR.scala
@@ -3,53 +3,61 @@ import scala.util.{Failure, Success, Try}
 object BankOCR {
 
   val pattern = Map(" _ " +
-                    "| |" +
-                    "|_|" -> "0",
-                    "   " +
-                    " | " +
-                    " | " -> "1",
-                    "   " +
-                    "  |" +
-                    "  |" -> "1",
-                    " _ " +
-                    " _|" +
-                    "|_ " -> "2",
-                    " _ " +
-                    " _|" +
-                    " _|" -> "3",
-                    "   " +
-                    "|_|" +
-                    "  |" -> "4",
-                    " _ " +
-                    "|_ " +
-                    " _|" -> "5",
-                    " _ " +
-                    "|_ " +
-                    "|_|" -> "6",
-                    " _ " +
-                    "  |" +
-                    "  |" -> "7",
-                    " _ " +
-                    "|_|" +
-                    "|_|" -> "8",
-                    " _ " +
-                    "|_|" +
-                    " _|" -> "9"
-                    )
+    "| |" +
+    "|_|" -> "0",
+    "   " +
+      " | " +
+      " | " -> "1",
+    "   " +
+      "  |" +
+      "  |" -> "1",
+    " _ " +
+      " _|" +
+      "|_ " -> "2",
+    " _ " +
+      " _|" +
+      " _|" -> "3",
+    "   " +
+      "|_|" +
+      "  |" -> "4",
+    " _ " +
+      "|_ " +
+      " _|" -> "5",
+    " _ " +
+      "|_ " +
+      "|_|" -> "6",
+    " _ " +
+      "  |" +
+      "  |" -> "7",
+    " _ " +
+      "|_|" +
+      "|_|" -> "8",
+    " _ " +
+      "|_|" +
+      " _|" -> "9"
+  )
 
   def readInput(input: String): String = {
     val accountNumberAsDigits: String = AccountNumberInput(input.substring(0, 27), input.substring(27, 54), input.substring(54, 81)).digits
-    if(accountNumberAsDigits.contains("?")) accountNumberAsDigits + " ILL"
-    else Try(evaluateChecksum(accountNumberAsDigits)) match {
-      case Success(_) => accountNumberAsDigits
-      case Failure(_) => accountNumberAsDigits + " ERR"
+    if (accountNumberAsDigits.contains("?")) {
+      accountNumberAsDigits + " ILL"
+    } else {
+      Try(evaluateChecksum(accountNumberAsDigits)) match {
+        case Success(_) => accountNumberAsDigits
+        case Failure(_) => accountNumberAsDigits + " ERR"
+      }
     }
   }
 
   def evaluateChecksum(input: String): Boolean = {
     val str: List[Int] = input.map(_.toString).map(_.toInt).toList
-    val strFormattedAsChecksum = Checksum(str.head,str(1),str(2),str(3),str(4),str(5),str(6),str(7),str(8))
-    if(strFormattedAsChecksum.isValid) true else throw new InvalidChecksumException("checksum invalid")
+    val strFormattedAsChecksum = Checksum(str.head, str(1), str(2), str(3), str(4), str(5), str(6), str(7), str(8))
+
+    if (strFormattedAsChecksum.isValid) {
+      true
+    } else {
+      throw new InvalidChecksumException("checksum invalid")
+    }
   }
 
   class InvalidChecksumException(msg: String) extends Exception(msg)
@@ -62,25 +70,23 @@ object BankOCR {
 
   case class AccountNumberInput(top: String, middle: String, bottom: String) {
 
+    def digits: String = {
+      val combinedDigits = for (positionInRow <- 0 until 27 by 3) yield {
+        val individualDigit = digitiser(positionInRow, positionInRow + 3)
+        individualDigit
+      }
+      combinedDigits.mkString
+    }
+
     def digitiser(start: Int, end: Int): String = {
       val num: String = top.substring(start, end) + middle.substring(start, end) + bottom.substring(start, end)
       val tryPattern: Try[String] = Try(pattern(num))
 
       tryPattern match {
-        case Success(_) => pattern(num)
+        case Success(x) => x
         case Failure(_) => "?"
       }
     }
 
-    val firstDigit: String = digitiser(0, 3)
-    val secondDigit: String = digitiser(3, 6)
-    val thirdDigit: String = digitiser(6, 9)
-    val fourthDigit: String = digitiser(9, 12)
-    val fifthDigit: String = digitiser(12, 15)
-    val sixthDigit: String = digitiser(15, 18)
-    val seventhDigit: String = digitiser(18, 21)
-    val eighthDigit: String = digitiser(21, 24)
-    val ninthDigit: String = digitiser(24, 27)
-    val digits: String = firstDigit + secondDigit + thirdDigit + fourthDigit + fifthDigit + sixthDigit + seventhDigit + eighthDigit + ninthDigit
   }
 }

--- a/src/main/scala/BankOCR.scala
+++ b/src/main/scala/BankOCR.scala
@@ -1,0 +1,60 @@
+object BankOCR {
+
+  val pattern = Map(" _ " +
+                    "| |" +
+                    "|_|" -> "0",
+                    "   " +
+                    " | " +
+                    " | " -> "1",
+                    " _ " +
+                    " _|" +
+                    "|_ " -> "2",
+                    " _ " +
+                    " _|" +
+                    " _|" -> "3",
+                    "   " +
+                    "|_|" +
+                    "  |" -> "4",
+                    " _ " +
+                    "|_ " +
+                    " _|" -> "5",
+                    " _ " +
+                    "|_ " +
+                    "|_|" -> "6",
+                    " _ " +
+                    "  |" +
+                    "  |" -> "7",
+                    " _ " +
+                    "|_|" +
+                    "|_|" -> "8",
+                    " _ " +
+                    "|_|" +
+                    "  |" -> "9"
+                    )
+
+  case class CR(top: String, middle: String, bottom: String) {
+    override def toString: String = top + middle + bottom
+
+    def digitiser(start: Int, end: Int): String =
+      top.substring(start,end) + middle.substring(start,end) + bottom.substring(start,end)
+
+    val firstDigit: String = digitiser(0,3)
+    val secondDigit: String = digitiser(3,6)
+    val thirdDigit: String = digitiser(6,9)
+    val fourthDigit: String = digitiser(9,12)
+    val fifthDigit: String = digitiser(12,15)
+    val sixthDigit: String = digitiser(15,18)
+    val seventhDigit: String = digitiser(18,21)
+    val eighthDigit: String = digitiser(21,24)
+    val ninthDigit: String = digitiser(24,27)
+
+    val digits: String = pattern(this.firstDigit) + pattern(this.secondDigit) + pattern(this.thirdDigit) +
+      pattern(this.fourthDigit) + pattern(this.fifthDigit) + pattern(this.sixthDigit) +
+      pattern(this.seventhDigit) + pattern(this.eighthDigit) + pattern(this.ninthDigit)
+  }
+
+  def readInput(input: String): String = {
+    CR(input.substring(0, 27), input.substring(27, 54), input.substring(54, 81)).digits
+  }
+
+}

--- a/src/test/scala/BankOCRSpec.scala
+++ b/src/test/scala/BankOCRSpec.scala
@@ -1,0 +1,34 @@
+import org.scalatest.{MustMatchers, WordSpec}
+
+class BankOCRSpec extends WordSpec with MustMatchers {
+
+  "BankOCR" when {
+
+    "readInput is called" must {
+
+      "return 00000000 when given the corresponding input" in {
+        val input = " _  _  _  _  _  _  _  _  _ " +
+                    "| || || || || || || || || |" +
+                    "|_||_||_||_||_||_||_||_||_|"
+        BankOCR.readInput(input) mustEqual "000000000"
+      }
+
+      "return 111111111 when given the corresponding input" in {
+        val input = "                           " +
+                    " |  |  |  |  |  |  |  |  | " +
+                    " |  |  |  |  |  |  |  |  | "
+        BankOCR.readInput(input) mustEqual "111111111"
+      }
+
+      "return 123456789 when given the corresponding input" in {
+        val input = "    _  _     _  _  _  _  _ " +
+                    " |  _| _||_||_ |_   ||_||_|" +
+                    " | |_  _|  | _||_|  ||_|  |"
+        BankOCR.readInput(input) mustEqual "123456789"
+      }
+
+    }
+
+  }
+
+}

--- a/src/test/scala/BankOCRSpec.scala
+++ b/src/test/scala/BankOCRSpec.scala
@@ -51,20 +51,20 @@ class BankOCRSpec extends WordSpec with MustMatchers {
 
     "checkSum is called" must {
 
-      "return true if the account number (123456789) has a valid checksum" in {
-        val input = "123456789"
+      "return true if the account number (899999999) has a valid checksum" in {
+        val input = "899999999"
         BankOCR.evaluateChecksum(input) mustEqual true
       }
 
-      "return false if the account number (232323235) does not have a valid checksum" in {
-        val input = "232323235"
+      "return false if the account number (999999999) does not have a valid checksum" in {
+        val input = "999999999"
         intercept[InvalidChecksumException] {
           BankOCR.evaluateChecksum(input)
         }
       }
 
-      "return false if the account number (111111111) does not have a valid checksum" in {
-        val input = "111111111"
+      "return false if the account number (490067715) does not have a valid checksum" in {
+        val input = "490067715"
         intercept[InvalidChecksumException] {
           BankOCR.evaluateChecksum(input)
         }

--- a/src/test/scala/BankOCRSpec.scala
+++ b/src/test/scala/BankOCRSpec.scala
@@ -9,35 +9,40 @@ class BankOCRSpec extends WordSpec with MustMatchers {
       "return 00000000 when given the corresponding input" in {
         val input = " _  _  _  _  _  _  _  _  _ " +
           "| || || || || || || || || |" +
-          "|_||_||_||_||_||_||_||_||_|"
+          "|_||_||_||_||_||_||_||_||_|" +
+          "                           "
         BankOCR.readInput(input) mustEqual "000000000"
       }
 
       "return 123456789 when given the corresponding input" in {
         val input = "    _  _     _  _  _  _  _ " +
           " |  _| _||_||_ |_   ||_||_|" +
-          " | |_  _|  | _||_|  ||_| _|"
+          " | |_  _|  | _||_|  ||_| _|" +
+          "                           "
         BankOCR.readInput(input) mustEqual "123456789"
       }
 
       "return 111111111 ERR when given the corresponding input" in {
         val input = "                           " +
           " |  |  |  |  |  |  |  |  | " +
-          " |  |  |  |  |  |  |  |  | "
+          " |  |  |  |  |  |  |  |  | " +
+          "                           "
         BankOCR.readInput(input) mustEqual "111111111 ERR"
       }
 
       "return '49006771? ILL' when given the corresponding input" in {
         val input = "    _  _  _  _  _  _     _ " +
           "|_||_|| || ||_   |  |  | _ " +
-          "  | _||_||_||_|  |  |  | _|"
+          "  | _||_||_||_|  |  |  | _|" +
+          "                           "
         BankOCR.readInput(input) mustEqual "49006771? ILL"
       }
 
       "return 1234?678? ILL when given the corresonding input" in {
         val input = "    _  _     _  _  _  _  _ " +
           "  | _| _||_| _ |_   ||_||_|" +
-          "  ||_  _|  | _||_|  ||_| _ "
+          "  ||_  _|  | _||_|  ||_| _ " +
+          "                           "
         BankOCR.readInput(input) mustEqual "1234?678? ILL"
       }
 

--- a/src/test/scala/BankOCRSpec.scala
+++ b/src/test/scala/BankOCRSpec.scala
@@ -1,3 +1,4 @@
+import BankOCR.InvalidChecksumException
 import org.scalatest.{MustMatchers, WordSpec}
 
 class BankOCRSpec extends WordSpec with MustMatchers {
@@ -57,14 +58,14 @@ class BankOCRSpec extends WordSpec with MustMatchers {
 
       "return false if the account number (232323235) does not have a valid checksum" in {
         val input = "232323235"
-        intercept[Exception] {
+        intercept[InvalidChecksumException] {
           BankOCR.evaluateChecksum(input)
         }
       }
 
       "return false if the account number (111111111) does not have a valid checksum" in {
         val input = "111111111"
-        intercept[Exception] {
+        intercept[InvalidChecksumException] {
           BankOCR.evaluateChecksum(input)
         }
       }

--- a/src/test/scala/BankOCRSpec.scala
+++ b/src/test/scala/BankOCRSpec.scala
@@ -8,23 +8,60 @@ class BankOCRSpec extends WordSpec with MustMatchers {
 
       "return 00000000 when given the corresponding input" in {
         val input = " _  _  _  _  _  _  _  _  _ " +
-                    "| || || || || || || || || |" +
-                    "|_||_||_||_||_||_||_||_||_|"
+          "| || || || || || || || || |" +
+          "|_||_||_||_||_||_||_||_||_|"
         BankOCR.readInput(input) mustEqual "000000000"
-      }
-
-      "return 111111111 when given the corresponding input" in {
-        val input = "                           " +
-                    " |  |  |  |  |  |  |  |  | " +
-                    " |  |  |  |  |  |  |  |  | "
-        BankOCR.readInput(input) mustEqual "111111111"
       }
 
       "return 123456789 when given the corresponding input" in {
         val input = "    _  _     _  _  _  _  _ " +
-                    " |  _| _||_||_ |_   ||_||_|" +
-                    " | |_  _|  | _||_|  ||_|  |"
+          " |  _| _||_||_ |_   ||_||_|" +
+          " | |_  _|  | _||_|  ||_| _|"
         BankOCR.readInput(input) mustEqual "123456789"
+      }
+
+      "return 111111111 ERR when given the corresponding input" in {
+        val input = "                           " +
+          " |  |  |  |  |  |  |  |  | " +
+          " |  |  |  |  |  |  |  |  | "
+        BankOCR.readInput(input) mustEqual "111111111 ERR"
+      }
+
+      "return '49006771? ILL' when given the corresponding input" in {
+        val input = "    _  _  _  _  _  _     _ " +
+          "|_||_|| || ||_   |  |  | _ " +
+          "  | _||_||_||_|  |  |  | _|"
+        BankOCR.readInput(input) mustEqual "49006771? ILL"
+      }
+
+      "return 1234?678? ILL when given the corresonding input" in {
+        val input = "    _  _     _  _  _  _  _ " +
+          "  | _| _||_| _ |_   ||_||_|" +
+          "  ||_  _|  | _||_|  ||_| _ "
+        BankOCR.readInput(input) mustEqual "1234?678? ILL"
+      }
+
+    }
+
+    "checkSum is called" must {
+
+      "return true if the account number (123456789) has a valid checksum" in {
+        val input = "123456789"
+        BankOCR.evaluateChecksum(input) mustEqual true
+      }
+
+      "return false if the account number (232323235) does not have a valid checksum" in {
+        val input = "232323235"
+        intercept[Exception] {
+          BankOCR.evaluateChecksum(input)
+        }
+      }
+
+      "return false if the account number (111111111) does not have a valid checksum" in {
+        val input = "111111111"
+        intercept[Exception] {
+          BankOCR.evaluateChecksum(input)
+        }
       }
 
     }


### PR DESCRIPTION
My first solution to the [Bank OCR kata](http://codingdojo.org/kata/BankOCR/).

- [x] User story 1: Parse pipe and underscore representations of numbers into a 9-digit bank account number.
- [x] User story 2: Test that bank account numbers input have a valid checksum.
- [x] User story 3: Output 'ERR' when the checksum fails, or 'ILL' when an illegible character is encountered during parsing.
- [ ] User story 4: In 'ILL' or 'ERR' cases, rescan the illegible character to see whether adding or removing a single pipe or underscore would make it a legible number with a valid checksum.  If this results in multiple possible account numbers, output an array marked 'AMB' (ambiguous).